### PR TITLE
fix: fixed thrown error for non-existent book

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -1,6 +1,6 @@
 from typing import OrderedDict
 
-from fastapi import APIRouter, status
+from fastapi import APIRouter, status, HTTPException
 from fastapi.responses import JSONResponse
 
 from api.db.schemas import Book, Genre, InMemoryDB
@@ -52,7 +52,7 @@ async def get_books() -> OrderedDict[int, Book]:
 async def get_book(book_id: int):
     book = db.get_book(book_id)  
     if not book:
-        return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content={"detail": "Book not found"})
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found")
     return JSONResponse(
         status_code=status.HTTP_200_OK, content=book.model_dump()
     )


### PR DESCRIPTION
## Description
- Fixed the `404 Not Found` error thrown by the `api/v1/books/{book_id}` endpoint